### PR TITLE
Migrate to access key

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -4,7 +4,6 @@ PROFILE_SLUG="default"
 # The public demo is not editable. Set this to true if you want to enable editing.
 NEXT_PUBLIC_EDITABLE=false
 
-# StatelyDB (get these from Stately Cloud)
+# StatelyDB (get these from the Stately Cloud console)
 STATELY_STORE_ID=your_store_id
-STATELY_CLIENT_ID=your_client_id
-STATELY_CLIENT_SECRET=your_client_secret
+STATELY_ACCESS_KEY=your_access_key

--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@ This is a sample NextJS webapp that uses StatelyDB.
    netlify env:set NEXT_PUBLIC_EDITABLE true
    netlify env:set PROFILE_SLUG default
    netlify env:set STATELY_STORE_ID your_store_id
-   netlify env:set STATELY_CLIENT_ID your_client_id
-   netlify env:set STATELY_CLIENT_SECRET your_client_secret
+   netlify env:set STATELY_ACCESS_KEY your_access_key
    ```
 4. Deploy to Netlify!
    ```
@@ -84,13 +83,12 @@ You only need to follow these steps if you want to make changes to the Schema lo
 
 1. For local development, create a `.env.local` file in the root directory with the following content:
    ```
-   STATELY_CLIENT_ID=your_client_id
-   STATELY_CLIENT_SECRET=your_client_secret
+   STATELY_ACCESS_KEY=your_access_key
    STATELY_STORE_ID=12345
    PROFILE_SLUG=default
    NEXT_PUBLIC_EDITABLE=false
    ```
-   Replace `your_client_id`, `your_client_secret`, and `12345` with your actual StatelyDB credentials and store ID.  Replace `your_base_url` with the base url of your app (e.g. `http://localhost:3000` or `https://statelydb-demo.netlify.app`).
+   Replace `your_access_key` and `12345` with your actual StatelyDB credentials and store ID.  Replace `your_base_url` with the base url of your app (e.g. `http://localhost:3000` or `https://statelydb-demo.netlify.app`).
    
    See `.env.local.example` for more details on the other configuration options.
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,5 +5,4 @@
   PROFILE_SLUG = "A partition key for the profile. You can leave this as 'default'."
   NEXT_PUBLIC_EDITABLE = "The public demo is not editable. Set this to true if you want to enable editing."
   STATELY_STORE_ID="The Store ID of your StatelyDB Store."
-  STATELY_CLIENT_ID="Your StatelyDB Client ID"
-  STATELY_CLIENT_SECRET="Your StatelyDB Client Secret"
+  STATELY_ACCESS_KEY="Your StatelyDB Access Key"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "netlify-starter-template",
       "version": "0.1.0",
       "dependencies": {
-        "@stately-cloud/client": "^0.12.0",
-        "@stately-cloud/schema": "^0.10.0",
+        "@stately-cloud/client": "^0.17.1",
+        "@stately-cloud/schema": "^0.12.1",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
         "next": "15.0.1",
@@ -49,25 +49,25 @@
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@connectrpc/connect": {
-      "version": "2.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.0.0-rc.3.tgz",
-      "integrity": "sha512-ARBt64yEyKbanyRETTjcjJuHr2YXorzQo0etyS5+P6oSeW8xEuzajA9g+zDnMcj1hlX2dQE93foIWQGfpru7gQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.0.0.tgz",
+      "integrity": "sha512-Usm8jgaaULANJU8vVnhWssSA6nrZ4DJEAbkNtXSoZay2YD5fDyMukCxu8NEhCvFzfHvrhxhcjttvgpyhOM7xAQ==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.2.0"
       }
     },
     "node_modules/@connectrpc/connect-node": {
-      "version": "2.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@connectrpc/connect-node/-/connect-node-2.0.0-rc.3.tgz",
-      "integrity": "sha512-lJEuqkpCfkELX0G8HFClLxh+3/lbwAC8EylXMTCL1+XUTwLXYc4DFORTmqCNObp723fW2mPlGDOpWy5t9m/fYg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect-node/-/connect-node-2.0.0.tgz",
+      "integrity": "sha512-DoI5T+SUvlS/8QBsxt2iDoUg15dSxqhckegrgZpWOtADtmGohBIVbx1UjtWmjLBrP4RdD0FeBw+XyRUSbpKnJQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.14.1"
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.2.0",
-        "@connectrpc/connect": "2.0.0-rc.3"
+        "@connectrpc/connect": "2.0.0"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -1242,14 +1242,14 @@
       "license": "MIT"
     },
     "node_modules/@stately-cloud/client": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@stately-cloud/client/-/client-0.12.0.tgz",
-      "integrity": "sha512-Sp4uwTVm5S5a+RBhvpc2cLfyzexLnreTuRUZJOrmEYXGB9fZ6fj/5eE1AP2+4tfByo+ImmlY8igy9QWMvLmxCw==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@stately-cloud/client/-/client-0.17.1.tgz",
+      "integrity": "sha512-R6P99w1DxNUSztuSMVyvKxnnGeWNcaAyp9+oC0n/sLl8G+zTmT564QBsPHJDHLvrfQVjkTRQqovtdqVcgflXkg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.2.0",
-        "@connectrpc/connect": "^2.0.0-rc.1",
-        "@connectrpc/connect-node": "^2.0.0-rc.1"
+        "@connectrpc/connect": "^2.0.0",
+        "@connectrpc/connect-node": "^2.0.0"
       },
       "engines": {
         "node": ">=18"
@@ -1259,9 +1259,9 @@
       }
     },
     "node_modules/@stately-cloud/schema": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@stately-cloud/schema/-/schema-0.10.0.tgz",
-      "integrity": "sha512-MgkuVKBN5HSZ+U8+cs9f1mCtB9wrQpE0Ho652RLnOAvuBG6vK4OEwy8fTSAoFxruB90tYXQSk9tfRnADbOmfeA==",
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@stately-cloud/schema/-/schema-0.12.1.tgz",
+      "integrity": "sha512-tRdfo+mVgcjPwzWp3jSuElRAx163rlXAsi3DfUZMakvGnvYshFW1FHr3AJNrnTen1Gnh7WjUTjQ698KZqpl+9g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.2.0",
@@ -4289,9 +4289,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@stately-cloud/client": "^0.12.0",
-    "@stately-cloud/schema": "^0.10.0",
+    "@stately-cloud/client": "^0.17.1",
+    "@stately-cloud/schema": "^0.12.1",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "next": "15.0.1",
@@ -29,5 +29,6 @@
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
     "typescript": "^5"
-  }
+  },
+  "packageManager": "pnpm@8.15.6+sha256.01c01eeb990e379b31ef19c03e9d06a14afa5250b82e81303f88721c99ff2e6f"
 }

--- a/schema/package-lock.json
+++ b/schema/package-lock.json
@@ -8,13 +8,13 @@
       "name": "schema",
       "version": "0.1.0",
       "dependencies": {
-        "@stately-cloud/schema": "^0.6.0"
+        "@stately-cloud/schema": "^0.12.1"
       }
     },
     "node_modules/@bufbuild/protobuf": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.2.2.tgz",
-      "integrity": "sha512-UNtPCbrwrenpmrXuRwn9jYpPoweNXj8X5sMvYgsqYyaH8jQ6LfUJSk3dJLnBK+6sfYPrF4iAIo5sd5HQ+tg75A==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.2.3.tgz",
+      "integrity": "sha512-tFQoXHJdkEOSwj5tRIZSPNUuXK3RaR7T1nUrPgbYX1pUbvqqaaZAsfo+NXBPsz5rZMSKVFrgK1WL8Q/MSLvprg==",
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -402,12 +402,12 @@
       }
     },
     "node_modules/@stately-cloud/schema": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@stately-cloud/schema/-/schema-0.6.0.tgz",
-      "integrity": "sha512-9Qy3PF0IPI6EeHRxJkcKigJecKHzlyqVYrULqC3SCFCSx5jMqJgmdHdDk9SFkeoUwZC/mqo218sv5L3eG+quvg==",
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@stately-cloud/schema/-/schema-0.12.1.tgz",
+      "integrity": "sha512-tRdfo+mVgcjPwzWp3jSuElRAx163rlXAsi3DfUZMakvGnvYshFW1FHr3AJNrnTen1Gnh7WjUTjQ698KZqpl+9g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@bufbuild/protobuf": "^2.1.0",
+        "@bufbuild/protobuf": "^2.2.0",
         "fast-equals": "^5.0.1",
         "tsx": "^4.7.1",
         "typescript": "^5.5.4"
@@ -519,9 +519,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
-      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
+      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/schema/package.json
+++ b/schema/package.json
@@ -5,6 +5,6 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "@stately-cloud/schema": "^0.6.0"
+    "@stately-cloud/schema": "^0.12.1"
   }
 }

--- a/src/lib/stately.ts
+++ b/src/lib/stately.ts
@@ -1,10 +1,8 @@
+import { accessKeyAuth } from "@stately-cloud/client";
 import { createClient } from "./generated/index.js";
 
-if (!process.env.STATELY_CLIENT_ID) {
-  throw new Error("Missing STATELY_CLIENT_ID");
-}
-if (!process.env.STATELY_CLIENT_SECRET) {
-  throw new Error("Missing STATELY_CLIENT_SECRET");
+if (!process.env.STATELY_ACCESS_KEY) {
+  throw new Error("Missing STATELY_ACCESS_KEY");
 }
 if (!process.env.STATELY_STORE_ID) {
   throw new Error("Missing STATELY_STORE_ID");
@@ -12,5 +10,7 @@ if (!process.env.STATELY_STORE_ID) {
 
 export const statelyClient = createClient(
   BigInt(process.env.STATELY_STORE_ID),
-  { region: "us-west-2" },
+  {
+    region: "us-west-2",
+  }
 );


### PR DESCRIPTION
* Swapped out `STATELY_CLIENT_ID` & `STATELY_CLIENT_SECRET` for `STATELY_ACCESS_KEY`
* Updated README
* Updated to latest published npm modules
* Purged deprecated environment variables

Note: This has been deployed.